### PR TITLE
793: Configure index base href to /rcs/ui

### DIFF
--- a/securebanking-cli-ui/scripts/buildThemes.js
+++ b/securebanking-cli-ui/scripts/buildThemes.js
@@ -72,8 +72,6 @@ async function build(project, customer) {
       "build",
       "--project",
       project,
-      "--base-href",
-      "/rcs/ui/",
       "--configuration",
       customer,
       "--output-path",

--- a/securebanking-cli-ui/scripts/buildThemes.js
+++ b/securebanking-cli-ui/scripts/buildThemes.js
@@ -72,6 +72,8 @@ async function build(project, customer) {
       "build",
       "--project",
       project,
+      "--base-href",
+      "/rcs/ui/",
       "--configuration",
       customer,
       "--output-path",

--- a/securebanking-rcs-ui/projects/rcs/docker/build-settings.js
+++ b/securebanking-rcs-ui/projects/rcs/docker/build-settings.js
@@ -3,14 +3,14 @@ module.exports = {
     head: [
       {
         id: 'title',
-        tag: '<title>Secure Banking Bank App</title>',
+        tag: '<title>Secure API gateway Resource Consent Service App</title>',
         order: 1
-      }
-      // {
-      //   id: 'description',
-      //   tag: '<meta name="description" content="">',
-      //   order: 2
-      // }
+      },
+      {
+        id: "base",
+        tag: '<base href="/rcs/ui/" />',
+        order: 2,
+      },
     ],
     body: {}
   }

--- a/securebanking-rcs-ui/projects/rcs/docker/build-settings.js
+++ b/securebanking-rcs-ui/projects/rcs/docker/build-settings.js
@@ -3,7 +3,7 @@ module.exports = {
     head: [
       {
         id: 'title',
-        tag: '<title>Secure API gateway Resource Consent Service App</title>',
+        tag: '<title>Secure API Gateway Consent Service App</title>',
         order: 1
       },
       {


### PR DESCRIPTION
Configure the RCS UI index base href to /rcs/ui/, this means that the UI is expected to run behind a reverse proxy that uses this prefix.

See related ingress PR: https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/pull/20

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/805