### PR TITLE
527: Fixing wrong displayed payee name

### DIFF
--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-payment-consent-details.js
@@ -8,21 +8,11 @@ module.exports = {
   clientName: "TPP Test application",
   serviceProviderName: "Forgerock Bank simulation config",
   initiation: {
-    debtorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "09090021325555",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    },
     creditorAccount: {
       schemeName: "UK.OBIE.SortCodeAccountNumber",
       identification: "08080021325698",
       name: "ACME Inc",
       secondaryIdentification: "0002"
-    },
-    remittanceInformation: {
-      unstructured: "Internal ops code 5120101",
-      reference: "FRESCO-101"
     }
   },
   instructedAmount: {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-payment-consent-details.js
@@ -7,6 +7,24 @@ module.exports = {
   clientId: "b437c832-e79c-4479-84b0-56e8ec403232",
   clientName: "TPP Test application",
   serviceProviderName: "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "09090021325555",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    remittanceInformation: {
+      unstructured: "Internal ops code 5120101",
+      reference: "FRESCO-101"
+    }
+  },
   instructedAmount: {
     amount: "165.88",
     currency: "GBP"

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-scheduled-payment-response-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-scheduled-payment-response-details.js
@@ -8,21 +8,11 @@ module.exports = {
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
   initiation: {
-    debtorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "09090021325555",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    },
     creditorAccount: {
       schemeName: "UK.OBIE.SortCodeAccountNumber",
       identification: "08080021325698",
       name: "ACME Inc",
       secondaryIdentification: "0002"
-    },
-    remittanceInformation: {
-      unstructured: "Internal ops code 5120101",
-      reference: "FRESCO-101"
     }
   },
   "instructedAmount": {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-scheduled-payment-response-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-scheduled-payment-response-details.js
@@ -7,6 +7,24 @@ module.exports = {
   "clientId": "5d649549-bfea-4f23-b071-618fcb74e37f",
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "09090021325555",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    remittanceInformation: {
+      unstructured: "Internal ops code 5120101",
+      reference: "FRESCO-101"
+    }
+  },
   "instructedAmount": {
     "amount": "10.01",
     "currency": "GBP"

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-standing-order-response-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-standing-order-response-details.js
@@ -7,6 +7,20 @@ module.exports = {
   "clientId": "63bce7d3-0c74-4188-9d24-88e3a69d3c80",
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "09090021325555",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+  },
   "standingOrder": {
       "type": "FRWriteDomesticStandingOrderDataInitiation",
       "frequency": "Paid on the 25th March, 24th June, 29th September and 25th December.",

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-standing-order-response-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/domestic-standing-order-response-details.js
@@ -8,18 +8,12 @@ module.exports = {
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
   initiation: {
-    debtorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "09090021325555",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    },
     creditorAccount: {
       schemeName: "UK.OBIE.SortCodeAccountNumber",
       identification: "08080021325698",
       name: "ACME Inc",
       secondaryIdentification: "0002"
-    },
+    }
   },
   "standingOrder": {
       "type": "FRWriteDomesticStandingOrderDataInitiation",

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-payment-consent-details.js
@@ -8,21 +8,11 @@ module.exports = {
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
   initiation: {
-    debtorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "09090021325555",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    },
     creditorAccount: {
       schemeName: "UK.OBIE.SortCodeAccountNumber",
       identification: "08080021325698",
       name: "ACME Inc",
       secondaryIdentification: "0002"
-    },
-    remittanceInformation: {
-      unstructured: "Internal ops code 5120101",
-      reference: "FRESCO-101"
     }
   },
   "instructedAmount": {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-payment-consent-details.js
@@ -7,6 +7,24 @@ module.exports = {
   "clientId": "ec0a5142-ea7c-4b82-8ff0-f24e3a526a9c",
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "09090021325555",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    remittanceInformation: {
+      unstructured: "Internal ops code 5120101",
+      reference: "FRESCO-101"
+    }
+  },
   "instructedAmount": {
     "amount": "10.01",
     "currency": "GBP"

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-scheduled-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-scheduled-payment-consent-details.js
@@ -8,21 +8,11 @@ module.exports = {
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
   initiation: {
-    debtorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "09090021325555",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    },
     creditorAccount: {
       schemeName: "UK.OBIE.SortCodeAccountNumber",
       identification: "08080021325698",
       name: "ACME Inc",
       secondaryIdentification: "0002"
-    },
-    remittanceInformation: {
-      unstructured: "Internal ops code 5120101",
-      reference: "FRESCO-101"
     }
   },
   "instructedAmount": {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-scheduled-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-scheduled-payment-consent-details.js
@@ -7,6 +7,24 @@ module.exports = {
   "clientId": "ec0a5142-ea7c-4b82-8ff0-f24e3a526a9c",
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "09090021325555",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    remittanceInformation: {
+      unstructured: "Internal ops code 5120101",
+      reference: "FRESCO-101"
+    }
+  },
   "instructedAmount": {
     "amount": "10.01",
     "currency": "GBP"

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-standing-order-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-standing-order-consent-details.js
@@ -8,18 +8,12 @@ module.exports = {
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
   initiation: {
-    debtorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "09090021325555",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    },
     creditorAccount: {
       schemeName: "UK.OBIE.SortCodeAccountNumber",
       identification: "08080021325698",
       name: "ACME Inc",
       secondaryIdentification: "0002"
-    },
+    }
   },
   "internationalStandingOrder": {
     "type": "FRWriteInternationalStandingOrderDataInitiation",

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-standing-order-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/international-standing-order-consent-details.js
@@ -7,6 +7,20 @@ module.exports = {
   "clientId": "aecab376-5c1d-4874-8549-475aa0eb68d2",
   "clientName": "TPP Test application",
   "serviceProviderName": "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "09090021325555",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    },
+  },
   "internationalStandingOrder": {
     "type": "FRWriteInternationalStandingOrderDataInitiation",
     "frequency": "Every working day.",

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/vrp-payment-consent-details.js
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent-dev/mocks/vrp-payment-consent-details.js
@@ -9,21 +9,11 @@ module.exports = {
   serviceProviderName: "Forgerock Bank simulation config",
   initiation: {
     type: "FRWriteDomesticVRPDataInitiation",
-    debtorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "09090021325555",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    },
     creditorAccount: {
       schemeName: "UK.OBIE.SortCodeAccountNumber",
       identification: "08080021325698",
       name: "ACME Inc",
       secondaryIdentification: "0002"
-    },
-    remittanceInformation: {
-      unstructured: "Internal ops code 5120101",
-      reference: "FRESCO-101"
     }
   },
   accounts: [

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormGroup, Validators, FormControl } from '@angular/forms';
+import _get from 'lodash-es/get';
 
 import { ApiResponses } from '../../../../../src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from '../../../../../src/app/types/consentItem';
@@ -32,14 +33,16 @@ export class DomesticPaymentComponent implements OnInit {
       return;
     }
 
-    this.items.push({
-      type: ItemType.STRING,
-      payload: {
-        label: 'CONSENT.PAYMENT.PAYEE_NAME',
-        value: this.response.clientName,
-        cssClass: 'domestic-single-payment-merchantName'
-      }
-    });
+    if (_get(this.response.initiation, 'creditorAccount')) {
+      this.items.push({
+        type: ItemType.STRING,
+        payload: {
+          label: 'CONSENT.PAYMENT.PAYEE_NAME',
+          value: this.response.initiation.creditorAccount.name,
+          cssClass: 'domestic-single-payment-merchantName'
+        }
+      });
+    }
     this.items.push({
       type: ItemType.STRING,
       payload: {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.ts
@@ -33,14 +33,16 @@ export class DomesticSchedulePaymentComponent implements OnInit {
       return;
     }
 
-    this.items.push({
-      type: ItemType.STRING,
-      payload: {
-        label: 'CONSENT.PAYMENT.PAYEE_NAME',
-        value: this.response.clientName,
-        cssClass: 'domestic-schedule-payment-merchantName'
-      }
-    });
+    if (_get(this.response.initiation, 'creditorAccount')) {
+      this.items.push({
+        type: ItemType.STRING,
+        payload: {
+          label: 'CONSENT.PAYMENT.PAYEE_NAME',
+          value: this.response.initiation.creditorAccount.name,
+          cssClass: 'domestic-schedule-payment-merchantName'
+        }
+      });
+    }
     this.items.push({
       type: ItemType.STRING,
       payload: {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
@@ -33,14 +33,16 @@ export class DomesticStandingOrderComponent implements OnInit {
       return;
     }
 
-    this.items.push({
-      type: ItemType.STRING,
-      payload: {
-        label: 'CONSENT.PAYMENT.PAYEE_NAME',
-        value: this.response.clientName,
-        cssClass: 'domestic-standing-order-merchantName'
-      }
-    });
+    if (_get(this.response.initiation, 'creditorAccount')) {
+      this.items.push({
+        type: ItemType.STRING,
+        payload: {
+          label: 'CONSENT.PAYMENT.PAYEE_NAME',
+          value: this.response.initiation.creditorAccount.name,
+          cssClass: 'domestic-standing-order-merchantName'
+        }
+      });
+    }
     this.items.push({
       type: ItemType.STRING,
       payload: {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.ts
@@ -35,14 +35,6 @@ export class FilePaymentComponent implements OnInit {
     this.items.push({
       type: ItemType.STRING,
       payload: {
-        label: 'CONSENT.PAYMENT.PAYEE_NAME',
-        value: this.response.clientName,
-        cssClass: 'file-payment-merchantName'
-      }
-    });
-    this.items.push({
-      type: ItemType.STRING,
-      payload: {
         label: 'CONSENT.PAYMENT.ACCOUNT',
         value: this.response.account,
         cssClass: 'file-payment-account'

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.ts
@@ -34,14 +34,16 @@ export class InternationalPaymentComponent implements OnInit {
       return;
     }
 
-    this.basicItems.push({
-      type: ItemType.STRING,
-      payload: {
-        label: 'CONSENT.PAYMENT.PAYEE_NAME',
-        value: this.response.clientName,
-        cssClass: 'international-payment-merchantName'
-      }
-    });
+    if (_get(this.response.initiation, 'creditorAccount')) {
+      this.basicItems.push({
+        type: ItemType.STRING,
+        payload: {
+          label: 'CONSENT.PAYMENT.PAYEE_NAME',
+          value: this.response.initiation.creditorAccount.name,
+          cssClass: 'international-payment-merchantName'
+        }
+      });
+    }
     this.basicItems.push({
       type: ItemType.STRING,
       payload: {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
@@ -34,14 +34,16 @@ export class InternationalSchedulePaymentComponent implements OnInit {
       return;
     }
 
-    this.basicItems.push({
-      type: ItemType.STRING,
-      payload: {
-        label: 'CONSENT.PAYMENT.PAYEE_NAME',
-        value: this.response.clientName,
-        cssClass: 'international-schedule-payment-merchantName'
-      }
-    });
+    if (_get(this.response.initiation, 'creditorAccount')) {
+      this.basicItems.push({
+        type: ItemType.STRING,
+        payload: {
+          label: 'CONSENT.PAYMENT.PAYEE_NAME',
+          value: this.response.initiation.creditorAccount.name,
+          cssClass: 'international-schedule-payment-merchantName'
+        }
+      });
+    }
     this.basicItems.push({
       type: ItemType.STRING,
       payload: {

--- a/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
+++ b/securebanking-rcs-ui/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
@@ -33,14 +33,16 @@ export class InternationalStandingOrderComponent implements OnInit {
       return;
     }
 
-    this.items.push({
-      type: ItemType.STRING,
-      payload: {
-        label: 'CONSENT.PAYMENT.PAYEE_NAME',
-        value: this.response.clientName,
-        cssClass: 'file-payment-merchantName'
-      }
-    });
+    if (_get(this.response.initiation, 'creditorAccount')) {
+      this.items.push({
+        type: ItemType.STRING,
+        payload: {
+          label: 'CONSENT.PAYMENT.PAYEE_NAME',
+          value: this.response.initiation.creditorAccount.name,
+          cssClass: 'file-payment-merchantName'
+        }
+      });
+    }
     this.items.push({
       type: ItemType.STRING,
       payload: {


### PR DESCRIPTION
Issue: https://github.com/secureapigateway/secureapigateway/issues/527
Description: Fixed the wrong displayed payee name for all Payment APIs. Also, removed the "payee name" field for the File Payment Consent since the consent response object doesn't have the creditorAccount field.